### PR TITLE
Add cpuload support and improve error handling

### DIFF
--- a/config/index.js
+++ b/config/index.js
@@ -15,6 +15,7 @@ const config = {
   user: env.AUTH_USER || 'test',
   password: env.AUTH_PW || 'test',
   port: parseInt(env.PORT, 10) || 3000,
+  debug: env.DEBUG === 'true',
 };
 
 module.exports = config;

--- a/server.js
+++ b/server.js
@@ -4,11 +4,24 @@ const basicAuth = require('express-basic-auth');
 const log4js = require('log4js');
 
 const config = require('./config');
-const pcRouter = require('./routes/inventory');
+
+// Logger configuration with optional debug mode and file output
+log4js.configure({
+  appenders: {
+    out: { type: 'stdout' },
+    app: { type: 'file', filename: 'app.log' },
+  },
+  categories: {
+    default: { appenders: ['out', 'app'], level: config.debug ? 'debug' : 'info' },
+  },
+});
 
 const logger = log4js.getLogger();
-logger.level = 'debug';
-logger.debug(`Debug mode active`);
+if (config.debug) {
+  logger.debug('Debug mode active');
+}
+
+const pcRouter = require('./routes/inventory');
 
 const app = express();
 
@@ -34,7 +47,7 @@ app.use(
 // HTTP request logging
 app.use(
   log4js.connectLogger(logger, {
-    level: 'debug',
+    level: config.debug ? 'debug' : 'info',
     format: (req, res, format) =>
       format(`:remote-addr :method :url ${JSON.stringify(req.body)}`),
   })

--- a/services/inventoryService.js
+++ b/services/inventoryService.js
@@ -5,6 +5,39 @@ const config = require('../config');
 
 const logger = log4js.getLogger();
 
+const requiredFields = [
+  'hostname',
+  'uuid',
+  'ip',
+  'os',
+  'version',
+  'uptime',
+  'cpuname',
+  'cpuload',
+  'ram',
+  'freemem',
+  'logonserver',
+  'loginuser',
+  'vendor',
+  'hardwarename',
+  'biosfirmwaretype',
+  'hdd',
+  'hddsize',
+  'hddfree',
+  'externalip',
+  'gateway',
+  'dnsserver',
+];
+
+function validatePc(pc) {
+  const missing = requiredFields.filter((field) => pc[field] === undefined);
+  if (missing.length) {
+    const error = new Error(`Missing required fields: ${missing.join(', ')}`);
+    error.statusCode = 400;
+    throw error;
+  }
+}
+
 // GET complete inventory
 async function getMultiple(page = 1) {
   const pageNumber = parseInt(page, 10) || 1;
@@ -38,10 +71,11 @@ async function getSingleItem(hostname) {
 
 // POST a new PC
 async function create(pc) {
+  validatePc(pc);
   const result = await db.query(
-    `INSERT INTO inventory 
-    (hostname, uuid, ip, os, version, uptime, cpuname, cpuload, ram, freemem, logonserver, loginuser, vendor, hardwarename, biosfirmwaretype, hdd, hddsize, hddfree, externalip, gateway, dnsserver) 
-    VALUES 
+    `INSERT INTO inventory
+    (hostname, uuid, ip, os, version, uptime, cpuname, cpuload, ram, freemem, logonserver, loginuser, vendor, hardwarename, biosfirmwaretype, hdd, hddsize, hddfree, externalip, gateway, dnsserver)
+    VALUES
     (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
     [pc.hostname, pc.uuid, pc.ip, pc.os, pc.version, pc.uptime, pc.cpuname, pc.cpuload, pc.ram, pc.freemem, pc.logonserver, pc.loginuser, pc.vendor, pc.hardwarename, pc.biosfirmwaretype, pc.hdd, pc.hddsize, pc.hddfree, pc.externalip, pc.gateway, pc.dnsserver]
   );
@@ -58,9 +92,10 @@ async function create(pc) {
 
 // Update inventory item via PUT-Request
 async function update(hostname, pc) {
+  validatePc(pc);
   const result = await db.query(
-    `UPDATE inventory 
-    SET uuid=?, ip=?, 
+    `UPDATE inventory
+    SET uuid=?, ip=?,
     os=?, version=?, uptime=?,
     cpuname=?, cpuload=?,
     ram=?, freemem=?, logonserver=?,

--- a/setup/db_setup.sql
+++ b/setup/db_setup.sql
@@ -3,37 +3,40 @@ SET AUTOCOMMIT = 0;
 START TRANSACTION;
 SET time_zone = "+00:00";
 
+-- SQL script to initialize inventory database and provide a sample entry
 
-/*!40101 SET @OLD_CHARACTER_SET_CLIENT=@@CHARACTER_SET_CLIENT */;
-/*!40101 SET @OLD_CHARACTER_SET_RESULTS=@@CHARACTER_SET_RESULTS */;
-/*!40101 SET @OLD_COLLATION_CONNECTION=@@COLLATION_CONNECTION */;
-/*!40101 SET NAMES utf8mb4 */;
-
-
+-- Table structure for table `inventory`
+DROP TABLE IF EXISTS `inventory`;
 CREATE TABLE `inventory` (
-  `id` int(11) NOT NULL,
+  `id` int(11) NOT NULL AUTO_INCREMENT,
   `hostname` varchar(255) COLLATE utf8_unicode_ci NOT NULL,
   `uuid` varchar(255) COLLATE utf8_unicode_ci NOT NULL,
   `ip` varchar(255) COLLATE utf8_unicode_ci NOT NULL,
   `os` varchar(255) COLLATE utf8_unicode_ci NOT NULL,
   `version` varchar(255) COLLATE utf8_unicode_ci NOT NULL,
   `uptime` varchar(255) COLLATE utf8_unicode_ci NOT NULL,
-  `updated_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
-) ENGINE=MyISAM DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+  `cpuname` varchar(255) COLLATE utf8_unicode_ci NOT NULL,
+  `cpuload` varchar(255) COLLATE utf8_unicode_ci NOT NULL,
+  `ram` varchar(255) COLLATE utf8_unicode_ci NOT NULL,
+  `freemem` varchar(255) COLLATE utf8_unicode_ci NOT NULL,
+  `logonserver` varchar(255) COLLATE utf8_unicode_ci NOT NULL,
+  `loginuser` varchar(255) COLLATE utf8_unicode_ci NOT NULL,
+  `vendor` varchar(255) COLLATE utf8_unicode_ci NOT NULL,
+  `hardwarename` varchar(255) COLLATE utf8_unicode_ci NOT NULL,
+  `biosfirmwaretype` varchar(255) COLLATE utf8_unicode_ci NOT NULL,
+  `hdd` varchar(255) COLLATE utf8_unicode_ci NOT NULL,
+  `hddsize` varchar(255) COLLATE utf8_unicode_ci NOT NULL,
+  `hddfree` varchar(255) COLLATE utf8_unicode_ci NOT NULL,
+  `externalip` varchar(255) COLLATE utf8_unicode_ci NOT NULL,
+  `gateway` varchar(255) COLLATE utf8_unicode_ci NOT NULL,
+  `dnsserver` varchar(255) COLLATE utf8_unicode_ci NOT NULL,
+  `updated_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `hostname` (`hostname`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 
-INSERT INTO `inventory` (`id`, `hostname`, `uuid`, `ip`, `os`, `version`, `uptime`, `updated_at`) VALUES
-(1, 'L11TEST-000001', 'deff0438-0776-4e75-b36d-da6eb2c0946e', '10.14.210.143', 'Windows 11', '10.2000', '120', '2021-12-31 23:00:03');
+-- Sample data for `inventory`
+INSERT INTO `inventory` (`id`, `hostname`, `uuid`, `ip`, `os`, `version`, `uptime`, `cpuname`, `cpuload`, `ram`, `freemem`, `logonserver`, `loginuser`, `vendor`, `hardwarename`, `biosfirmwaretype`, `hdd`, `hddsize`, `hddfree`, `externalip`, `gateway`, `dnsserver`, `updated_at`) VALUES
+(1, 'L11TEST-000001', 'deff0438-0776-4e75-b36d-da6eb2c0946e', '10.14.210.143', 'Windows 11', '10.2000', '120', 'Intel(R) CPU', '5', '16GB', '8GB', 'LOGSERVER', 'user', 'Dell', 'OptiPlex', 'UEFI', 'SSD', '512GB', '256GB', '203.0.113.1', '10.14.210.1', '8.8.8.8', '2021-12-31 23:00:03');
 
-
-ALTER TABLE `inventory`
-  ADD PRIMARY KEY (`id`),
-  ADD UNIQUE KEY `hostname` (`hostname`);
-
-
-ALTER TABLE `inventory`
-  MODIFY `id` int(11) NOT NULL AUTO_INCREMENT, AUTO_INCREMENT=33;
 COMMIT;
-
-/*!40101 SET CHARACTER_SET_CLIENT=@OLD_CHARACTER_SET_CLIENT */;
-/*!40101 SET CHARACTER_SET_RESULTS=@OLD_CHARACTER_SET_RESULTS */;
-/*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;


### PR DESCRIPTION
## Summary
- log all errors to a file and allow debug mode via `DEBUG` env var
- validate required fields for inventory updates and creates
- expand DB schema with CPU load and other hardware details

## Testing
- `npm test` *(fails: /usr/bin/npm: No such file or directory)*
- `apt-get update` *(fails: The repository 'http://archive.ubuntu.com/ubuntu noble InRelease' is not signed.)*

------
https://chatgpt.com/codex/tasks/task_e_68b55a0c778c83289e734ac98ec171f4