### PR TITLE
feat: add route for listing hostnames

### DIFF
--- a/routes/inventory.js
+++ b/routes/inventory.js
@@ -16,6 +16,16 @@ router.get('/', async (req, res, next) => {
   }
 });
 
+// GET hostnames sorted by latest update
+router.get('/hostnames', async (req, res, next) => {
+  try {
+    res.json(await pc.getHostnames());
+  } catch (err) {
+    logger.error(`Error while getting hostnames`, err.message);
+    next(err);
+  }
+});
+
 // GET single item by hostname
 router.get('/hostname/:hostname', async (req, res, next) => {
   try {

--- a/services/inventoryService.js
+++ b/services/inventoryService.js
@@ -66,6 +66,15 @@ async function getByHostname(hostname) {
   return { data };
 }
 
+// GET hostnames sorted by latest update
+async function getHostnames() {
+  const rows = await db.query(
+    `SELECT hostname, id, updated_at, ip, externalip, uptime FROM inventory ORDER BY updated_at DESC`
+  );
+  const data = helper.emptyOrRows(rows);
+  return { data };
+}
+
 // POST a new PC
 async function create(pc) {
   validatePc(pc);
@@ -135,6 +144,7 @@ module.exports = {
   getAll,
   getById,
   getByHostname,
+  getHostnames,
   create,
   update,
   remove,


### PR DESCRIPTION
## Summary
- expose `/hostnames` endpoint to list all hosts sorted by last update
- select hostname, id, updated_at, ip, externalip, uptime from inventory table

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68b566326d1883289733f7afc8fd533d